### PR TITLE
Introduce encode_text() for encoding lines of text

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All Vestaboard characters (letters, numbers, symbols, and colors) are encoded
 as integer [character codes](https://docs.vestaboard.com/characters). Vesta
 includes some useful routines for working with these character codes.
 
-`encode(s)` encodes a string as a list of character codes. In addition to
+`encode()` encodes a string as a list of character codes. In addition to
 printable characters, the string can contain character code sequences inside
 curly braces, such as `{5}` or `{65}`.
 
@@ -56,12 +56,26 @@ curly braces, such as `{5}` or `{65}`.
 [67, 0, 8, 5, 12, 12, 15, 55, 0, 23, 15, 18, 12, 4, 0, 68]
 ```
 
-`encode_row(s)` encodes a string as a row of character codes. It builds on
-`encode(s)` by providing alignment control.
+`encode_row()` encodes a string as a row of character codes. It builds on
+`encode()` by providing alignment control.
 
 ```python
 >>> vesta.encode_row("{67} Hello, World {68}", align="center")
 [0, 0, 0, 67, 0, 8, 5, 12, 12, 15, 55, 0, 23, 15, 18, 12, 4, 0, 68, 0, 0, 0]
+```
+
+`encode_text()` encodes a string of text into rows of character codes, further
+building on `encode()` and `encode_row()` with the addition of margin control
+and line breaks.
+
+```python
+>>> encode_text("multiple\nlines\nof\ntext", align="center")
+[
+    [0, 0, 0, 0, 0, 0, 0, 13, 21, 12, 20, 9, 16, 12, 5, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 12, 9, 14, 5, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 5, 24, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+]
 ```
 
 Lastly, `pprint()` can be used to pretty-print encoded characters to the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ includes some useful routines for working with these character codes.
 
 .. autofunction:: vesta.encode
 .. autofunction:: vesta.encode_row
+.. autofunction:: vesta.encode_text
 
 .. autofunction:: vesta.pprint
 

--- a/tests/test_chars.py
+++ b/tests/test_chars.py
@@ -1,9 +1,11 @@
 import unittest
 
+from vesta.chars import COLS
 from vesta.chars import CHARCODES
 from vesta.chars import Color
 from vesta.chars import encode
 from vesta.chars import encode_row
+from vesta.chars import encode_text
 
 
 class EncodeTests(unittest.TestCase):
@@ -33,19 +35,19 @@ class EncodeRowTests(unittest.TestCase):
     def test_align_left(self):
         self.assertEqual(
             [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            encode_row("abc", align='left'),
+            encode_row("abc", align="left"),
         )
 
     def test_align_center(self):
         self.assertEqual(
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            encode_row("abc", align='center'),
+            encode_row("abc", align="center"),
         )
 
     def test_align_right(self):
         self.assertEqual(
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3],
-            encode_row("abc", align='right'),
+            encode_row("abc", align="right"),
         )
 
     def test_unknown_alignment(self):
@@ -55,6 +57,79 @@ class EncodeRowTests(unittest.TestCase):
 
     def test_fill(self):
         self.assertEqual(
-            [1, 2, 3] + [int(Color.GREEN)] * 19,
+            [1, 2, 3] + [int(Color.GREEN)] * (COLS - 3),
             encode_row("abc", align="left", fill=Color.GREEN),
+        )
+
+
+class EncodeTextTests(unittest.TestCase):
+    def test_newlines(self):
+        self.assertEqual(
+            [
+                [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            encode_text("a\nb\nc"),
+        )
+
+    def test_align_left(self):
+        self.assertEqual(
+            [
+                [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            encode_text("a\nb", align="left"),
+        )
+
+    def test_align_center(self):
+        self.assertEqual(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            encode_text("a\nb", align="center"),
+        )
+
+    def test_align_right(self):
+        self.assertEqual(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
+            ],
+            encode_text("a\nb", align="right"),
+        )
+
+    def test_unknown_alignment(self):
+        self.assertRaisesRegex(
+            ValueError, "unknown alignment", encode_text, "a", align="unknown"
+        )
+
+    def test_margin(self):
+        self.assertEqual(
+            [
+                [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+                [0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            encode_text("a" * COLS, margin=1),
+        )
+
+    def test_fill(self):
+        self.assertEqual(
+            [
+                [1, 2, 3] + [Color.GREEN] * (COLS - 3),
+            ],
+            encode_text("abc", align="left", fill=Color.GREEN),
+        )
+
+    def test_breaks(self):
+        self.assertEqual(
+            # fmt: off
+            [
+                [23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 0, 0],  # noqa
+                [0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 0],  # noqa
+                [0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],  # noqa
+            ],
+            # fmt: on
+            encode_text(" ".join(["word"] * 10)),
         )

--- a/vesta/__init__.py
+++ b/vesta/__init__.py
@@ -1,6 +1,7 @@
 from .chars import Color
 from .chars import encode
 from .chars import encode_row
+from .chars import encode_text
 from .chars import pprint
 from .client import Client
 
@@ -8,6 +9,7 @@ __all__ = (
     'Color',
     'encode',
     'encode_row',
+    'encode_text',
     'pprint',
     'Client',
 )


### PR DESCRIPTION
`encode_text()` encodes a string of text into rows of character codes,
further building on `encode()` and `encode_row()` with the addition of
margin control and line breaks.