### PR TITLE
Drop official support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy3]
+        python-version: [3.7, 3.8, 3.9, '3.10', 'pypy-3.7']
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ keywords = vestaboard
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >= 3.6
+python_requires = >= 3.7
 zip_safe = True
 
 [tool:pytest]


### PR DESCRIPTION
Python 3.6 will reach its official end-of-life on December 23. Given
we are a new project, I don't think we need to offer explicit support
for that version.