### PR TITLE
Raise ValueError if `message` is the wrong shape

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,13 @@
+import unittest
+
+from vesta.client import Client
+
+
+class TestClient(unittest.TestCase):
+    def setUp(self):
+        self.client = Client("key", "secret")
+
+    def test_post_message_dimensions(self):
+        self.assertRaisesRegex(
+            ValueError, "expected a \\(6, 22\\) array", self.client.post_message, "", []
+        )

--- a/vesta/client.py
+++ b/vesta/client.py
@@ -8,6 +8,9 @@ from urllib.parse import urljoin
 
 import requests
 
+from .chars import COLS
+from .chars import ROWS
+
 __all__ = ["Client"]
 
 
@@ -73,18 +76,24 @@ class Client:
 
         The authenticated viewer must have access to the subscription.
 
-        `message` can be either a string of text or a two-dimensional array of
-        character codes representing the exact positions of characters on the
-        board.
+        `message` can be either a string of text or a two-dimensional (6, 22)
+        array of character codes representing the exact positions of characters
+        on the board.
 
         If text is specified, lines will be centered horizontally and
         vertically if possible. Character codes will be inferred for
         alphanumeric and punctuation, or can be explicitly specified in-line in
         the message with curly braces containing the character code.
+
+        :raises ValueError: if `message` is a list with unsupported dimensions
         """
         if isinstance(message, str):
             data = {"text": message}
         elif isinstance(message, list):
+            if len(message) != ROWS or not all(len(row) == COLS for row in message):
+                raise ValueError(
+                    f"expected a ({ROWS}, {COLS}) array of encoded characters"
+                )
             data = {"characters": message}
         else:
             raise TypeError(f"unsupported message type: {type(message)}")


### PR DESCRIPTION
When you post an array of encoded characters, the Vestaboard API expects
the list to contain six full rows of 22 characters.

See #13