### PR TITLE
Move pytest coverage options to setup.cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
           isort --check --diff .
       - name: Tests
         run: |
-          python -m pytest -v --cov=vesta --cov-report=term-missing
+          python -m pytest -v --cov-config=setup.cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >= 3.7
 zip_safe = True
 
 [tool:pytest]
-addopts = --doctest-modules
+addopts = --cov=vesta --cov-report=term-missing --doctest-modules
 testpaths = vesta tests
 
 [coverage:run]


### PR DESCRIPTION
This makes these options the "default" for all pytest runs within this
project. It also makes them a little bit more discoverable than burying
them within the GitHub-specific workflow file.

Also, explicitly specifying the coverage configuration file to avoid
running into any potential issues with .coveragerc:

https://pytest-cov.readthedocs.io/en/latest/config.html#caveats