### PR TITLE
More specific post_message() typing

### DIFF
--- a/vesta/client.py
+++ b/vesta/client.py
@@ -90,7 +90,7 @@ class Client:
     def post_message(
         self,
         subscription_id: str,
-        message: Union[str, list],
+        message: Union[str, List[List[int]]],
     ) -> Dict[str, Any]:
         """Post of a new message to a subscription.
 


### PR DESCRIPTION
We specifically expect the second form of the `message` value to be a
two-dimensional list of integer values, not just any untyped list.