### PR TITLE
Remove the explicit coverage dependency

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 black==22.3.0
-coverage==6.3.2
 flake8==4.0.1
 isort==5.10.1
 mypy==0.950


### PR DESCRIPTION
pytest-cov depends on coverage, so we don't need to depend directly on a
transitive package.