### PR TITLE
Add py.typed to package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,9 @@ packages = find:
 python_requires = >= 3.7
 zip_safe = True
 
+[options.package_data]
+vesta = py.typed
+
 [tool:pytest]
 addopts = --cov=vesta --cov-report=term-missing --doctest-modules
 testpaths = vesta tests


### PR DESCRIPTION
PEP 561 requires that this file be distributed as part of the package's
data in order to indicate that this package supports typing.

https://peps.python.org/pep-0561/#packaging-type-information