### PR TITLE
Introduce Row and Rows type aliases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,11 @@ intersphinx_mapping = {
 }
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+autodoc_type_aliases = {
+    "Row": "vesta.chars.Row",
+    "Rows": "vesta.chars.Rows",
+}
+
 
 # HTML
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,9 @@ All Vestaboard characters (letters, numbers, symbols, and colors) are encoded
 as integer `character codes <https://docs.vestaboard.com/characters>`_. Vesta
 includes some useful routines for working with these character codes.
 
+.. autodata:: vesta.chars.Row
+.. autodata:: vesta.chars.Rows
+
 .. autoclass:: vesta.Color
     :show-inheritance:
     :members:

--- a/vesta/chars.py
+++ b/vesta/chars.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import enum
 import math
 import sys
@@ -33,6 +35,12 @@ ROWS = 6
 COLS = 22
 PRINTABLE = " ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$() - +&=;: '\"%,.  /? °"
 CHARMAP = {c: i for i, c in enumerate(PRINTABLE) if i == 0 or c != " "}
+
+#: A row of character codes.
+Row = List[int]
+
+#: A list of rows, forming a character grid.
+Rows = List[Row]
 
 
 class Color(enum.IntEnum):
@@ -62,7 +70,7 @@ class Color(enum.IntEnum):
 CHARCODES = frozenset(CHARMAP.values()).union(Color)
 
 
-def encode(s: str) -> List[int]:
+def encode(s: str) -> Row:
     """Encodes a string as a list of character codes.
 
     In addition to printable characters, the string can contain character code
@@ -100,7 +108,7 @@ def encode(s: str) -> List[int]:
     return out
 
 
-def encode_row(s: str, align: str = "left", fill: int = Color.BLACK) -> List[int]:
+def encode_row(s: str, align: str = "left", fill: int = Color.BLACK) -> Row:
     """Encodes a string as a row of character codes.
 
     In addition to printable characters, the string can contain character code
@@ -132,7 +140,7 @@ def encode_text(
     margin: int = 0,
     fill: int = Color.BLACK,
     breaks: Container[int] = frozenset({0}),
-) -> List[List[int]]:
+) -> Rows:
     """Encodes a string of text into rows of character codes.
 
     In addition to printable characters, the string can contain character code
@@ -169,9 +177,9 @@ def encode_text(
     """
     fill = int(fill)
     max_cols = COLS - margin * 2
-    rows: List[List[int]] = []
+    rows: Rows = []
 
-    def find_break(line: List[int]) -> Tuple[int, int]:
+    def find_break(line: Row) -> Tuple[int, int]:
         end = min(len(line), max_cols)
         for pos in range(end, 0, -1):
             if line[pos] in breaks:
@@ -204,7 +212,7 @@ def encode_text(
     return rows
 
 
-def _format_row(row: List[int], align: str, margin: int, fill: int) -> List[int]:
+def _format_row(row: Row, align: str, margin: int, fill: int) -> Row:
     assert len(row) <= COLS - margin * 2
 
     if align == "left":
@@ -223,7 +231,7 @@ def _format_row(row: List[int], align: str, margin: int, fill: int) -> List[int]
 
 
 def pprint(
-    data: Union[List[int], List[List[int]]],
+    data: Union[Row, Rows],
     stream: TextIO = sys.stdout,
     *,
     sep: str = "|",
@@ -233,10 +241,7 @@ def pprint(
 
     ``data`` may be a single list or a two-dimensional array of character codes.
     """
-    rows = cast(
-        List[List[int]],
-        data if data and isinstance(data[0], list) else [data],
-    )
+    rows = cast(Rows, data if data and isinstance(data[0], list) else [data])
 
     # Assume all TTYs support color.
     colors = stream.isatty()

--- a/vesta/client.py
+++ b/vesta/client.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 from typing import Any
 from typing import Dict
 from typing import List
@@ -30,6 +32,7 @@ import requests
 
 from .chars import COLS
 from .chars import ROWS
+from .chars import Rows
 
 __all__ = ["Client"]
 
@@ -96,7 +99,7 @@ class Client:
     def post_message(
         self,
         subscription_id: str,
-        message: Union[str, List[List[int]]],
+        message: Union[str, Rows],
     ) -> Dict[str, Any]:
         """Post of a new message to a subscription.
 
@@ -113,7 +116,7 @@ class Client:
 
         :raises ValueError: if `message` is a list with unsupported dimensions
         """
-        data: Dict[str, Union[str, List[List[int]]]]
+        data: Dict[str, Union[str, Rows]]
         if isinstance(message, str):
             data = {"text": message}
         elif isinstance(message, list):


### PR DESCRIPTION
These are more self-documenting than the bare `List[int]`-based types that
they wrap.
