### PR TITLE
Improve the Local API enablement flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ in order to use the Local API.
 import vesta
 local_client = vesta.LocalClient()
 
-# The Vestaboard's Local API must be enabled once to get its Local API key.
-r = local_client.enable(ENABLEMENT_TOKEN)
-local_client.api_key = r["apiKey"]
+# The Vestaboard's Local API must be enabled to get its Local API key. After
+# you've done this once, you can save the key somewhere safe and pass it
+# directly to LocalClient() for future client initializations.
+local_api_key = local_client.enable(ENABLEMENT_TOKEN)
+# e.g. local_client = LocalClient(local_api_key)
+assert local_client.enabled
 
-# Then, you can write and read messages.
+# Once enabled, you can write and read messages:
 message = vesta.encode("{67} Hello, World {68}")
 assert local_client.write_message(message)
 assert local_client.read_message() == message

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -101,13 +101,17 @@ class TestLocalClient:
         assert local_client.enabled
         assert local_client.api_key == local_api_key
 
-    def test_enable(self, local_client: LocalClient, requests_mock: Mocker):
+    def test_enable(self, requests_mock: Mocker):
+        local_client = LocalClient()
+        local_api_key = "key"
         requests_mock.post(
             "http://vestaboard.local:7000/local-api/enablement",
-            json={"message": "Local API enabled", "apiKey": "key"},
+            json={"apiKey": local_api_key},
         )
-        r = local_client.enable("enablement_token")
-        assert "apiKey" in r
+        rv = local_client.enable("enablement_token")
+        assert rv == local_api_key
+        assert local_client.api_key == local_api_key
+        assert local_client.enabled
         assert requests_mock.last_request
         assert (
             requests_mock.last_request.headers.get(
@@ -115,6 +119,14 @@ class TestLocalClient:
             )
             == "enablement_token"
         )
+
+    def test_enable_failure(self, requests_mock: Mocker):
+        local_client = LocalClient()
+        requests_mock.post("http://vestaboard.local:7000/local-api/enablement")
+        rv = local_client.enable("enablement_token")
+        assert rv is None
+        assert not local_client.api_key
+        assert not local_client.enabled
 
     def test_not_enabled(self):
         local_client = LocalClient()


### PR DESCRIPTION
Calling `enable()` now sets the client's `api_key` property and returns the
Local API key for future reuse. This is a friendlier pattern than asking
the user to do all of that work.