### PR TITLE
Switch to HTTPX as the underlying HTTP library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0 - Not yet released
+### Changed
+- Switched to [HTTPX](https://www.python-httpx.org/) as the underlying HTTP library.
+
 ## 0.8.0 - 2022-08-13
 ### Added
 - `LocalClient` provides a client interface to Vestaboard's Local API.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Vesta requires Python 3.7 or later. It can be installed [via PyPI][pypi]:
 $ python -m pip install vesta
 ```
 
-Its only runtime dependency is the [Requests library][requests], which will be
+Its only runtime dependency is the [HTTPX library][httpx], which will be
 installed automatically.
 
 [pypi]: https://pypi.org/project/vesta/
-[requests]: https://requests.readthedocs.io/
+[httpx]: https://www.python-httpx.org/
 
 ## Usage
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,10 @@ Vesta requires Python 3.7 or later. It can be installed `via PyPI
 
     $ python -m pip install vesta
 
-It's only runtime dependency is the `Requests`_ library, which will be
+It's only runtime dependency is the `HTTPX`_ library, which will be
 installed automatically.
 
-.. _Requests: https://requests.readthedocs.io/
+.. _HTTPX: https://www.python-httpx.org/
 
 API Clients
 ===========

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ from setuptools import setup
 setup(
     name="vesta",
     install_requires=[
-        "requests>=2.27.0",
+        "httpx>=0.23.1",
     ],
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,5 +4,4 @@ isort==5.10.1
 mypy==0.991
 pytest==7.2.0
 pytest-cov==4.0.0
-requests-mock==1.10.0
-types-requests==2.28.0
+respx==0.20.1

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
 import pytest
-from requests_mock import Mocker
 
 from vesta.chars import COLS
 from vesta.chars import ROWS
 from vesta.clients import Client
 from vesta.clients import LocalClient
 from vesta.clients import ReadWriteClient
+
+if TYPE_CHECKING:
+    from respx import MockRouter
 
 
 @pytest.fixture
@@ -27,52 +34,41 @@ class TestClient:
     def test_base_url(self):
         base_url = "https://www.example.com"
         client = Client("key", "secret", base_url=base_url)
-        assert client.session.base_url == base_url
+        assert client.http.base_url == base_url
         assert base_url in repr(client)
 
     def test_headers(self):
         client = Client("key", "secret", headers={"User-Agent": "Vesta"})
-        assert client.session.headers["X-Vestaboard-Api-Key"] == "key"
-        assert client.session.headers["X-Vestaboard-Api-Secret"] == "secret"
-        assert client.session.headers["User-Agent"] == "Vesta"
+        assert client.http.headers["X-Vestaboard-Api-Key"] == "key"
+        assert client.http.headers["X-Vestaboard-Api-Secret"] == "secret"
+        assert client.http.headers["User-Agent"] == "Vesta"
 
-    def test_get_subscriptions(self, client: Client, requests_mock: Mocker):
+    def test_get_subscriptions(self, client: Client, respx_mock: MockRouter):
         subscriptions = [True]
-        requests_mock.get(
-            "https://platform.vestaboard.com/subscriptions",
-            json={"subscriptions": subscriptions},
+        respx_mock.get("https://platform.vestaboard.com/subscriptions").respond(
+            json={"subscriptions": subscriptions}
         )
         assert client.get_subscriptions() == subscriptions
 
-    def test_get_viewer(self, client: Client, requests_mock: Mocker):
+    def test_get_viewer(self, client: Client, respx_mock: MockRouter):
         viewer = {"_id": 1}
-        requests_mock.get("https://platform.vestaboard.com/viewer", json=viewer)
+        respx_mock.get("https://platform.vestaboard.com/viewer").respond(json=viewer)
         assert client.get_viewer() == viewer
 
-    def test_post_message_text(self, client: Client, requests_mock: Mocker):
+    def test_post_message_text(self, client: Client, respx_mock: MockRouter):
         text = "abc"
-
-        def match_json(request) -> bool:
-            return request.json() == {"text": text}
-
-        requests_mock.post(
+        respx_mock.post(
             "https://platform.vestaboard.com/subscriptions/sub_id/message",
-            additional_matcher=match_json,
-            json={},
-        )
+            json={"text": text},
+        ).respond(json={})
         client.post_message("sub_id", text)
 
-    def test_post_message_list(self, client: Client, requests_mock: Mocker):
+    def test_post_message_list(self, client: Client, respx_mock: MockRouter):
         chars = [[0] * COLS] * ROWS
-
-        def match_json(request) -> bool:
-            return request.json() == {"characters": chars}
-
-        requests_mock.post(
+        respx_mock.post(
             "https://platform.vestaboard.com/subscriptions/sub_id/message",
-            additional_matcher=match_json,
-            json={},
-        )
+            json={"characters": chars},
+        ).respond(json={})
         client.post_message("sub_id", chars)
 
     def test_post_message_list_dimensions(self, client: Client):
@@ -88,7 +84,7 @@ class TestLocalClient:
     def test_base_url(self):
         base_url = "http://example.local"
         local_client = LocalClient("key", base_url=base_url)
-        assert local_client.session.base_url == base_url
+        assert local_client.http.base_url == base_url
         assert base_url in repr(local_client)
 
     def test_api_key_init(self):
@@ -107,28 +103,27 @@ class TestLocalClient:
         assert local_client.enabled
         assert local_client.api_key == local_api_key
 
-    def test_enable(self, requests_mock: Mocker):
+    def test_enable(self, respx_mock: MockRouter):
         local_client = LocalClient()
         local_api_key = "key"
-        requests_mock.post(
-            "http://vestaboard.local:7000/local-api/enablement",
+        respx_mock.post("http://vestaboard.local:7000/local-api/enablement").respond(
             json={"apiKey": local_api_key},
         )
         rv = local_client.enable("enablement_token")
         assert rv == local_api_key
         assert local_client.api_key == local_api_key
         assert local_client.enabled
-        assert requests_mock.last_request
+        assert respx_mock.calls.called
         assert (
-            requests_mock.last_request.headers.get(
+            respx_mock.calls.last.request.headers.get(
                 "X-Vestaboard-Local-Api-Enablement-Token"
             )
             == "enablement_token"
         )
 
-    def test_enable_failure(self, requests_mock: Mocker):
+    def test_enable_failure(self, respx_mock: MockRouter):
         local_client = LocalClient()
-        requests_mock.post("http://vestaboard.local:7000/local-api/enablement")
+        respx_mock.post("http://vestaboard.local:7000/local-api/enablement")
         rv = local_client.enable("enablement_token")
         assert rv is None
         assert not local_client.api_key
@@ -141,27 +136,27 @@ class TestLocalClient:
         with pytest.raises(RuntimeError, match=r"Local API has not been enabled"):
             local_client.write_message([])
 
-    def test_read_message(self, local_client: LocalClient, requests_mock: Mocker):
+    def test_read_message(self, local_client: LocalClient, respx_mock: MockRouter):
         chars = [[0] * COLS] * ROWS
-        requests_mock.get(
-            "http://vestaboard.local:7000/local-api/message", json={"message": chars}
+        respx_mock.get("http://vestaboard.local:7000/local-api/message").respond(
+            json={"message": chars}
         )
         message = local_client.read_message()
         assert message == chars
 
-    def test_read_message_empty(self, local_client: LocalClient, requests_mock: Mocker):
-        requests_mock.get("http://vestaboard.local:7000/local-api/message")
+    def test_read_message_empty(
+        self, local_client: LocalClient, respx_mock: MockRouter
+    ):
+        respx_mock.get("http://vestaboard.local:7000/local-api/message")
         message = local_client.read_message()
         assert message is None
 
-    def test_write_message(self, local_client: LocalClient, requests_mock: Mocker):
+    def test_write_message(self, local_client: LocalClient, respx_mock: MockRouter):
         chars = [[0] * COLS] * ROWS
-        requests_mock.post(
-            "http://vestaboard.local:7000/local-api/message", status_code=201
-        )
+        respx_mock.post("http://vestaboard.local:7000/local-api/message").respond(201)
         assert local_client.write_message(chars)
-        assert requests_mock.last_request
-        assert requests_mock.last_request.json() == chars
+        assert respx_mock.calls.called
+        assert respx_mock.calls.last.request.content == json.dumps(chars).encode()
 
     def test_write_message_dimensions(self, local_client: LocalClient):
         with pytest.raises(ValueError, match=rf"expected a \({ROWS}, {COLS}\) array"):
@@ -172,36 +167,35 @@ class TestReadWriteClient:
     def test_base_url(self):
         base_url = "http://example.local"
         rw_client = ReadWriteClient("key", base_url=base_url)
-        assert rw_client.session.base_url == base_url
+        assert rw_client.http.base_url == base_url
         assert base_url in repr(rw_client)
 
     def test_headers(self):
         client = ReadWriteClient("key", headers={"User-Agent": "Vesta"})
-        assert client.session.headers["X-Vestaboard-Read-Write-Key"] == "key"
-        assert client.session.headers["User-Agent"] == "Vesta"
+        assert client.http.headers["X-Vestaboard-Read-Write-Key"] == "key"
+        assert client.http.headers["User-Agent"] == "Vesta"
 
-    def test_read_message(self, rw_client: ReadWriteClient, requests_mock: Mocker):
+    def test_read_message(self, rw_client: ReadWriteClient, respx_mock: MockRouter):
         chars = [[0] * COLS] * ROWS
-        requests_mock.get(
-            "https://rw.vestaboard.com",
+        respx_mock.get("https://rw.vestaboard.com/").respond(
             json={"currentMessage": {"layout": chars}},
         )
         message = rw_client.read_message()
         assert message == chars
 
     def test_read_message_empty(
-        self, rw_client: ReadWriteClient, requests_mock: Mocker
+        self, rw_client: ReadWriteClient, respx_mock: MockRouter
     ):
-        requests_mock.get("https://rw.vestaboard.com")
+        respx_mock.get("https://rw.vestaboard.com/")
         message = rw_client.read_message()
         assert message is None
 
-    def test_write_message(self, rw_client: ReadWriteClient, requests_mock: Mocker):
+    def test_write_message(self, rw_client: ReadWriteClient, respx_mock: MockRouter):
         chars = [[0] * COLS] * ROWS
-        requests_mock.post("https://rw.vestaboard.com", status_code=201)
+        respx_mock.post("https://rw.vestaboard.com/").respond(201)
         assert rw_client.write_message(chars)
-        assert requests_mock.last_request
-        assert requests_mock.last_request.json() == chars
+        assert respx_mock.calls.called
+        assert respx_mock.calls.last.request.content == json.dumps(chars).encode()
 
     def test_write_message_dimensions(self, rw_client: ReadWriteClient):
         with pytest.raises(ValueError, match=rf"expected a \({ROWS}, {COLS}\) array"):

--- a/vesta/__init__.py
+++ b/vesta/__init__.py
@@ -18,4 +18,4 @@ __all__ = (
     "ReadWriteClient",
 )
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
Requests worked fine, but HTTPX feels like the better maintained library moving forward. HTTPX also brings the following immediate advantages:

1. It ships with full type annotations out-of-the-box.
2. It has built-in `base_url` support, so we can drop some custom code.
3. It offers async and HTTP/2 support, should we want them in the future.

The RESPX library is used for testing.