### PR TITLE
Avoid importing full package to read docs version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,16 +1,24 @@
 import datetime
 import os
-import sys
+import re
 
-sys.path.insert(0, os.path.abspath(".."))
 
-from vesta import __version__ as version
+def get_version(filename):
+    docsdir = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(docsdir, filename)) as f:
+        version_file = f.read()
+    version_match = re.search(r"^__version__ = \"([^\"]*)\"", version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 # Project
 
 project = "Vesta"
 copyright = f"{datetime.date.today().year} Jon Parise"
 author = "Jon Parise"
+version = get_version("../vesta/__init__.py")
 release = version
 
 # General


### PR DESCRIPTION
Importing the `vesta` package also requires its dependencies, and that complicates the docs build. Instead, we extract the `__version__` string directly from the `vesta/__init__.py` source file.