### PR TITLE
Switch to actions/setup-python-based caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-pip
+          cache: 'pip'
+          cache-dependency-path: 'tests/requirements.txt'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
actions/setup-python includes built-in support for caching package dependencies. We can use it instead of the separate actions/cache action.