### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
+        python-version: [3.8, 3.9, '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
 - Switched to [HTTPX](https://www.python-httpx.org/) as the underlying HTTP library.
 
+### Removed
+- Dropped support for Python 3.7.
+
 ## 0.8.0 - 2022-08-13
 ### Added
 - `LocalClient` provides a client interface to Vestaboard's Local API.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It provides API clients and character encoding utilities.
 
 ## Installation
 
-Vesta requires Python 3.7 or later. It can be installed [via PyPI][pypi]:
+Vesta requires Python 3.8 or later. It can be installed [via PyPI][pypi]:
 
 ```sh
 $ python -m pip install vesta

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Python. It provides API clients and character encoding utilities.
 Installation
 ============
 
-Vesta requires Python 3.7 or later. It can be installed `via PyPI
+Vesta requires Python 3.8 or later. It can be installed `via PyPI
 <https://pypi.org/project/vesta/>`_::
 
     $ python -m pip install vesta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ force_single_line = true
 multi_line_output = 3
 
 [tool.mypy]
-python_version = 3.7
+python_version = 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ keywords = vestaboard
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10


### PR DESCRIPTION
Python 3.7 will reach the end of its supported life in June 2023. I was planning to wait until that date to drop support for Python 3.7 in this library, but I'm just going to do it now because ...

1. There are four newer 3.x Python versions out there, and they should be accessible to everyone that is currently running 3.7.
2. This is a small, niche library that's only about a year old, so I don't think this change will impact a large install base.
3. There are a few Python 3.8+ features I want to use (like `Literal`), and it's not worth looking for compatibility options for only a six month support window.