### PR TITLE
Use a readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+---
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
This is the recommended way to configure readthedocs for a project. It also appears to be the only way to explicitly specify a Python version.

https://docs.readthedocs.io/en/stable/config-file/v2.html