### PR TITLE
Fix ReadWriteClient.get_message() result type

### DIFF
--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -178,7 +178,7 @@ class TestReadWriteClient:
     def test_read_message(self, rw_client: ReadWriteClient, respx_mock: MockRouter):
         chars = [[0] * COLS] * ROWS
         respx_mock.get("https://rw.vestaboard.com/").respond(
-            json={"currentMessage": {"layout": chars}},
+            json={"currentMessage": {"layout": json.dumps(chars)}},
         )
         message = rw_client.read_message()
         assert message == chars

--- a/vesta/clients.py
+++ b/vesta/clients.py
@@ -248,9 +248,12 @@ class ReadWriteClient:
         r = self.http.get("")
         r.raise_for_status()
         try:
-            return r.json().get("currentMessage", {}).get("layout")
+            layout = r.json().get("currentMessage", {}).get("layout")
         except json.JSONDecodeError:
             return None
+        if layout:
+            return json.loads(layout)
+        return None
 
     def write_message(self, message: Rows) -> bool:
         """Write a message to the Vestaboard.


### PR DESCRIPTION
This method was previously returning a JSON-encoded string value representing the rows. We instead want to decode that string and return a full `Rows` value (list of lists).