### PR TITLE
Add the sphinxext-opengraph extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
+    "sphinxext.opengraph",
 ]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx==7.0.1
 furo==2023.5.20
+sphinxext-opengraph==0.8.2


### PR DESCRIPTION
This extension automatically adds OpenGraph metadata to the generated documentation.