### PR TITLE
Build documentation with Python 3.9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Sphinx has dropped support for Python 3.8:
https://github.com/sphinx-doc/sphinx/pull/11511