### PR TITLE
Remove sys.path manipulation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,4 @@
 import datetime
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(".."))
 
 from vesta import __version__ as version
 


### PR DESCRIPTION
Documentation should always be built in an environment in which the 'vesta' package has been installed.