### PR TITLE
Switch to Ruff as the primary lint tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,7 @@ jobs:
           pip install -e .[lint,test,typing]
       - name: Lint
         run: |
-          flake8
-          black --check --diff .
-          isort --check --diff .
+          ruff check --output-format=github
       - name: Typing
         run: |
           python -m mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,7 @@ docs = [
     "furo==2023.9.10",
 ]
 lint = [
-    "black==23.12.0",
-    "flake8==7.0.0",
-    "isort==5.13.0",
+    "ruff==0.1.11",
 ]
 test = [
     "pytest==7.4.0",
@@ -61,14 +59,19 @@ version = {attr = "vesta.__version__"}
 branch = true
 source = ["src"]
 
-[tool.isort]
-profile = "black"
-force_single_line = true
-multi_line_output = 3
-
 [tool.mypy]
 packages = ["vesta", "tests"]
 python_version = 3.8
 
 [tool.pytest.ini_options]
 addopts = "--cov=vesta --cov-report=term-missing --doctest-modules"
+
+[tool.ruff]
+select = ["E", "F", "I", "RUF", "W"]
+src = ["src", "tests"]
+
+[tool.ruff.lint.isort]
+force-single-line = true
+
+[tool.ruff.per-file-ignores]
+"tests/test_chars.py" = ["E501"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length: 88
-exclude = .venv/*,build/*,docs/*
-extend-ignore: E203
-per-file-ignores =
-    # ignore line lengths in encoding tests
-    tests/test_chars.py: E501

--- a/src/vesta/chars.py
+++ b/src/vesta/chars.py
@@ -70,16 +70,16 @@ class Color(enum.IntEnum):
         return obj
 
     # fmt: off
-    BLANK   = (0,  "\033[0m")   # noqa: E221
-    RED     = (63, "\033[31m")  # noqa: E221
-    ORANGE  = (64, "\033[33m")  # noqa: E221
-    YELLOW  = (65, "\033[93m")  # noqa: E221
-    GREEN   = (66, "\033[32m")  # noqa: E221
-    BLUE    = (67, "\033[94m")  # noqa: E221
-    VIOLET  = (68, "\033[95m")  # noqa: E221
-    WHITE   = (69, "\033[97m")  # noqa: E221
-    BLACK   = (70, "\033[0m")   # noqa: E221
-    FILLED  = (71, "\033[97m")  # noqa: E221
+    BLANK   = (0,  "\033[0m")
+    RED     = (63, "\033[31m")
+    ORANGE  = (64, "\033[33m")
+    YELLOW  = (65, "\033[93m")
+    GREEN   = (66, "\033[32m")
+    BLUE    = (67, "\033[94m")
+    VIOLET  = (68, "\033[95m")
+    WHITE   = (69, "\033[97m")
+    BLACK   = (70, "\033[0m")
+    FILLED  = (71, "\033[97m")
     # fmt: on
 
 

--- a/tests/test_chars.py
+++ b/tests/test_chars.py
@@ -185,16 +185,16 @@ class TestEncodeText:
         assert encode_text("abc", align="left", fill=Color.GREEN) == chars
 
     def test_breaks(self):
+        # fmt: off
         chars = [
-            # fmt: off
             [23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 0, 0],
             [23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 0, 0],
             [23, 15, 18, 4, 0, 23, 15, 18, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            # fmt: on
         ]
+        # fmt: on
         assert encode_text(" ".join(["word"] * 10)) == chars
 
 
@@ -206,9 +206,7 @@ class TestPrint:
 
     def test_row(self):
         chars = encode_row("{63} Centered {63}", align="center")
-        assert self.pprint(chars) == (
-            "| | | | | |◼︎| |C|E|N|T|E|R|E|D| |◼︎| | | | | |\n"
-        )
+        assert self.pprint(chars) == ("| | | | | |◼︎| |C|E|N|T|E|R|E|D| |◼︎| | | | | |\n")
 
     def test_rows(self):
         chars = encode_text("{63} Centered {63}", align="center", valign="middle")
@@ -235,9 +233,7 @@ class TestPrint:
         output = io.StringIO()
         monkeypatch.setattr(output, "isatty", lambda: True)
         pprint([65], stream=output)
-        assert (
-            output.getvalue() == "\x1b[90m|\x1b[0m\x1b[93m◼︎\x1b[0m\x1b[90m|\x1b[0m\n"
-        )
+        assert output.getvalue() == "\x1b[90m|\x1b[0m\x1b[93m◼︎\x1b[0m\x1b[90m|\x1b[0m\n"
 
     def test_unknown_character_code(self):
         pytest.raises(ValueError, pprint, [99]).match("unknown character code: 99")


### PR DESCRIPTION
Ruff replaces black, flake8, and isort.

https://docs.astral.sh/ruff/