### PR TITLE
Remove explicit setuptools installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip
           pip install -e .[lint,test,typing]
       - name: Lint
         run: |


### PR DESCRIPTION
This should be handled by 'build-system.requires' pyproject.toml key.