### PR TITLE
Include the changelog in the Sphinx documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.12.0 - Unreleased
 ### Added
-- All clients now support a user-provided [`httpx.Client`](https://www.python-httpx.org/api/#client)
+- All clients now support a user-provided [httpx.Client](https://www.python-httpx.org/api/#client)
   objects.
 
 ## 0.11.0 - 2024-01-22

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../CHANGELOG.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
+    "sphinx_mdinclude",
 ]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,11 @@ Vesta
 Vesta is a `Vestaboard <https://www.vestaboard.com/>`_ client library for
 Python. It provides API clients and character encoding utilities.
 
+.. toctree::
+   :hidden:
+
+   changelog
+
 Installation
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 docs = [
     "Sphinx==7.2.2",
     "furo==2023.9.10",
+    "sphinx_mdinclude==0.5.3",
 ]
 lint = [
     "ruff==0.1.11",


### PR DESCRIPTION
We use the sphinx-mdinclude extension to include the Markdown-formatted CHANGELOG.md content into the reStructuredText-based documentation.