### PR TITLE
Add SubscriptionClient for the Subscription API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 0.12.0 - Unreleased
 ### Added
-- All clients now support a user-provided [httpx.Client](https://www.python-httpx.org/api/#client)
-  objects.
+- All clients now support a user-provided [httpx.Client](https://www.python-httpx.org/api/#client).
 - Added support for the VBML `absolutePosition` style.
 - Added support for the VBML `rawCharacters` component field.
+- `SubscriptionClient` provides a client interface to Vestaboard's Subscription API.
 
 ### Changed
 - The `encode_*()` functions now consistently specify keyword-only arguments.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ assert rw_client.write_message(message)
 assert rw_client.read_message() == message
 ```
 
+#### `SubscriptionClient`
+
+`SubscriptionClient` provides a client interface for interacting with multiple
+Vestaboards using the [Subscription API](https://docs.vestaboard.com/docs/subscription-api/introduction).
+
+Note that an API secret and key is required to get subscriptions or send
+messages. These credentials can be created from the [Developer section of the
+web app](https://web.vestaboard.com/).
+
+```py
+import vesta
+subscription_client = vesta.SubscriptionClient("api_key", "api_secret")
+
+# List subscriptions and send them messages:
+subscriptions = subscription_client.get_subscriptions()
+for subscription in subscriptions:
+    subscription_client.send_message(subscription["id"], "Hello World")
+```
+
 #### `VBMLClient`
 
 `VBMLClient` provides a client interface for Vestaboard's [VBML (Vestaboard

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,10 +57,27 @@ with a Vestaboard using the `Read / Write API
 .. important::
 
     A Read / Write API key is required to read or write messages. This key is
-    obtained by enabling the Vestaboard's Read / Write API via the Settings
-    section of the mobile app or from the Developer section of the web app.
+    obtained by enabling the Vestaboard's Read / Write API via the *Settings*
+    section of the mobile app or from the `Developer section of the web app
+    <https://web.vestaboard.com/>`_.
 
 .. autoclass:: vesta.ReadWriteClient
+    :members:
+
+``SubscriptionClient``
+----------------------
+
+:py:class:`vesta.SubscriptionClient` provides a client interface for interacting
+with multiple Vestaboards using the `Subscription API
+<https://docs.vestaboard.com/docs/subscription-api/introduction>`_.
+
+.. important::
+
+    An API secret and key is required to get subscriptions or send messages.
+    These credentials can be created from the `Developer section of the web
+    app <https://web.vestaboard.com/>`_.
+
+.. autoclass:: vesta.SubscriptionClient
     :members:
 
 ``VBMLClient``

--- a/src/vesta/__init__.py
+++ b/src/vesta/__init__.py
@@ -6,6 +6,7 @@ from .chars import pprint
 from .clients import Client
 from .clients import LocalClient
 from .clients import ReadWriteClient
+from .clients import SubscriptionClient
 from .clients import VBMLClient
 
 __all__ = (
@@ -17,6 +18,7 @@ __all__ = (
     "Client",
     "LocalClient",
     "ReadWriteClient",
+    "SubscriptionClient",
     "VBMLClient",
 )
 


### PR DESCRIPTION
This API is a new revision of the original Platform API. I'll probably start to deprecate the latter (our original `Client` interface) soon.