### PR TITLE
Deprecate the Platform API (Client interface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Changed
 - The `encode_*()` functions now consistently specify keyword-only arguments.
+- Vestaboard has deprecated the Platform API, so our `Client` interface is also
+  considered deprecated. Switch to `SubscriptionClient`, which offers nearly
+  identical functionality.
 
 ## 0.11.0 - 2024-01-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,37 +21,45 @@ installed automatically.
 
 ### API Clients
 
-#### `Client`
+#### Read / Write API
 
-The `Client` type is initialized with an API key and secret:
+`ReadWriteClient` provides a client interface for interacting with a Vestaboard
+using the [Read / Write API](https://docs.vestaboard.com/docs/read-write-api/introduction).
 
-```pycon
->>> import vesta
->>> client = vesta.Client(API_KEY, API_SECRET)
+Note that Vestaboard owners must first obtain their Read / Write API key by
+enabling the Vestaboard's Read / Write API via the Settings section of the
+mobile app or from the Developer section of the web app.
+
+```py
+import vesta
+rw_client = vesta.ReadWriteClient("read_write_key")
+
+# Once enabled, you can write and read messages:
+message = vesta.encode_text("{67} Hello, World {68}")
+assert rw_client.write_message(message)
+assert rw_client.read_message() == message
 ```
 
-Then, you can make API calls using one of the provided methods:
+#### Subscription API
 
-```pycon
->>> client.get_viewer()
-{'_id': ..., '_created': '1629081092624', 'type': 'installation', 'installation': {'_id': ...}}
+`SubscriptionClient` provides a client interface for interacting with multiple
+Vestaboards using the [Subscription API](https://docs.vestaboard.com/docs/subscription-api/introduction).
 
->>> client.get_subscriptions()
-[{'_id': ..., '_created': '1629081092624', 'title': None, 'icon': None, 'installation': {'_id': ..., 'installable': {'_id': ...}}, 'boards': [{'_id': ...}]}]
+Note that an API secret and key is required to get subscriptions or send
+messages. These credentials can be created from the [Developer section of the
+web app](https://web.vestaboard.com/).
 
->>> client.post_message(SUBSCRIPTION_ID, "Hello, World")
-{'message': {'id': ..., 'text': 'Hello, World', 'created': '1635801572442'}}
+```py
+import vesta
+subscription_client = vesta.SubscriptionClient("api_key", "api_secret")
+
+# List subscriptions and send them messages:
+subscriptions = subscription_client.get_subscriptions()
+for subscription in subscriptions:
+    subscription_client.send_message(subscription["id"], "Hello World")
 ```
 
-Messages can be posted as either text strings or two-dimensional arrays of
-character codes representing the exact positions of characters on the board.
-
-If text is specified, the lines will be centered horizontally and vertically.
-Character codes will be inferred for alphanumeric and punctuation characters,
-or they can be explicitly specified using curly braces containing the character
-code (such as `{5}` or `{65}`).
-
-#### `LocalClient`
+#### Local API
 
 `LocalClient` provides a client interface for interacting with a Vestaboard
 over the local network using [Vestaboard's Local API](https://docs.vestaboard.com/docs/local-api/introduction).
@@ -77,45 +85,7 @@ assert local_client.write_message(message)
 assert local_client.read_message() == message
 ```
 
-#### `ReadWriteClient`
-
-`ReadWriteClient` provides a client interface for interacting with a Vestaboard
-using the [Read / Write API](https://docs.vestaboard.com/docs/read-write-api/introduction).
-
-Note that Vestaboard owners must first obtain their Read / Write API key by
-enabling the Vestaboard's Read / Write API via the Settings section of the
-mobile app or from the Developer section of the web app.
-
-```py
-import vesta
-rw_client = vesta.ReadWriteClient("read_write_key")
-
-# Once enabled, you can write and read messages:
-message = vesta.encode_text("{67} Hello, World {68}")
-assert rw_client.write_message(message)
-assert rw_client.read_message() == message
-```
-
-#### `SubscriptionClient`
-
-`SubscriptionClient` provides a client interface for interacting with multiple
-Vestaboards using the [Subscription API](https://docs.vestaboard.com/docs/subscription-api/introduction).
-
-Note that an API secret and key is required to get subscriptions or send
-messages. These credentials can be created from the [Developer section of the
-web app](https://web.vestaboard.com/).
-
-```py
-import vesta
-subscription_client = vesta.SubscriptionClient("api_key", "api_secret")
-
-# List subscriptions and send them messages:
-subscriptions = subscription_client.get_subscriptions()
-for subscription in subscriptions:
-    subscription_client.send_message(subscription["id"], "Hello World")
-```
-
-#### `VBMLClient`
+#### VBML API
 
 `VBMLClient` provides a client interface for Vestaboard's [VBML (Vestaboard
 Markup Language)](https://docs.vestaboard.com/docs/vbml) API.
@@ -134,6 +104,26 @@ component = Component(
 vbml_client = vesta.VBMLClient()
 vesta.pprint(vbml_client.compose([component]))
 ```
+
+#### Platform Client
+
+`Client` provides a client interface for interacting with the **deprecated**
+[Vestaboard Platform API](https://docs-v1.vestaboard.com/introduction).
+
+This is the original Vestaboard Platform API. It is **deprecated** and has been
+superseded by the other APIs listed above. In particular, Vestaboard encourages
+users of the Platform API to switch to the [Subscription API](#subscription-api),
+which offers nearly identical functionality.
+
+### Messages
+
+Messages can be posted as either text strings or two-dimensional arrays of
+character codes representing the exact positions of characters on the board.
+
+If text is specified, the lines will be centered horizontally and vertically.
+Character codes will be inferred for alphanumeric and punctuation characters,
+or they can be explicitly specified using curly braces containing the character
+code (such as `{5}` or `{65}`).
 
 ### Character Encoding
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,29 +26,8 @@ installed automatically.
 API Clients
 ===========
 
-``Client``
-----------
-
-.. autoclass:: vesta.Client
-    :members:
-
-``LocalClient``
----------------
-
-:py:class:`vesta.LocalClient` provides a client interface for interacting with
-a Vestaboard over the local network using `Vestaboard's Local API
-<https://docs.vestaboard.com/docs/local-api/introduction>`_.
-
-.. important::
-
-    Vestaboard owners must first request a `Local API enablement token
-    <https://www.vestaboard.com/local-api>`_ in order to use the Local API.
-
-.. autoclass:: vesta.LocalClient
-    :members:
-
-``ReadWriteClient``
--------------------
+Read / Write API
+----------------
 
 :py:class:`vesta.ReadWriteClient` provides a client interface for interacting
 with a Vestaboard using the `Read / Write API
@@ -64,8 +43,8 @@ with a Vestaboard using the `Read / Write API
 .. autoclass:: vesta.ReadWriteClient
     :members:
 
-``SubscriptionClient``
-----------------------
+Subscription API
+----------------
 
 :py:class:`vesta.SubscriptionClient` provides a client interface for interacting
 with multiple Vestaboards using the `Subscription API
@@ -80,14 +59,45 @@ with multiple Vestaboards using the `Subscription API
 .. autoclass:: vesta.SubscriptionClient
     :members:
 
-``VBMLClient``
---------------
+Local API
+---------
+
+:py:class:`vesta.LocalClient` provides a client interface for interacting with
+a Vestaboard over the local network using `Vestaboard's Local API
+<https://docs.vestaboard.com/docs/local-api/introduction>`_.
+
+.. important::
+
+    Vestaboard owners must first request a `Local API enablement token
+    <https://www.vestaboard.com/local-api>`_ in order to use the Local API.
+
+.. autoclass:: vesta.LocalClient
+    :members:
+
+VBML API
+--------
 
 :py:class:`vesta.VBMLClient` provides a client interface for Vestaboard's
 `VBML (Vestaboard Markup Language) <https://docs.vestaboard.com/docs/vbml>`_
 API.
 
 .. autoclass:: vesta.VBMLClient
+    :members:
+
+Platform API
+------------
+
+:py:class:`vesta.Client` provides a client interface for interacting with the
+**deprecated** `Vestaboard Platform API <https://docs-v1.vestaboard.com/introduction>`_.
+
+.. warning::
+
+    This is the original Vestaboard Platform API. It is **deprecated** and has
+    been superseded by the other APIs listed above. In particular, Vestaboard
+    encourages users of the Platform API to switch to the Subscription API,
+    which offers nearly identical functionality.
+
+.. autoclass:: vesta.Client
     :members:
 
 Character Encoding

--- a/examples/dadjokes.py
+++ b/examples/dadjokes.py
@@ -55,7 +55,7 @@ def main(args: argparse.Namespace):
         level=logging.INFO,
     )
 
-    client = vesta.Client(args.key, args.secret)
+    client = vesta.SubscriptionClient(args.key, args.secret)
 
     jokes = fetch_jokes(args.count)
     logging.info("Loaded %d jokes", len(jokes))
@@ -81,7 +81,7 @@ def main(args: argparse.Namespace):
             vesta.pprint(chars)
 
         try:
-            client.post_message(args.sub, chars)
+            client.send_message(args.sub, chars)
         except httpx.HTTPStatusError as e:
             logging.error(e)
             time.sleep(60)

--- a/src/vesta/clients.py
+++ b/src/vesta/clients.py
@@ -47,6 +47,8 @@ class Client:
     Optionally, an alternate ``base_url`` can be specified, as well as any
     additional HTTP ``headers`` that should be sent with every request
     (such as a custom `User-Agent` header).
+
+    .. deprecated:: 0.12
     """
 
     def __init__(


### PR DESCRIPTION
Vestaboard has deprecated the Platform API, so our `Client` interface is also considered deprecated. Switch to the `SubscriptionClient`, which offers nearly identical functionality.

Also, revise the documentation for the other clients to match the order used by Vestaboard's developer documentation.