### PR TITLE
Upgrade the Read the Docs environment to 3.10

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Sphinx 8+ requires Python 3.10.