### PR TITLE
Drop support for Python 3.8 and add 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.9', 'pypy-3.10']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It provides API clients and character encoding utilities.
 
 ## Installation
 
-Vesta requires Python 3.8 or later. It can be installed [via PyPI][pypi]:
+Vesta requires Python 3.9 or later. It can be installed [via PyPI][pypi]:
 
 ```sh
 $ python -m pip install vesta

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Python. It provides API clients and character encoding utilities.
 Installation
 ============
 
-Vesta requires Python 3.8 or later. It can be installed `via PyPI
+Vesta requires Python 3.9 or later. It can be installed `via PyPI
 <https://pypi.org/project/vesta/>`_::
 
     $ python -m pip install vesta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
     "httpx>=0.23.1",
 ]
@@ -58,7 +58,7 @@ source = ["src"]
 
 [tool.mypy]
 packages = ["vesta", "tests"]
-python_version = 3.8
+python_version = 3.9
 
 [tool.pytest.ini_options]
 addopts = "--cov=vesta --cov-report=term-missing --doctest-modules"


### PR DESCRIPTION
Python 3.8 has reached its end-of-life.