### PR TITLE
Use dependency-groups for development dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          pip install -e . --group dev
       - name: Lint
         run: |
           ruff check --output-format=github

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,13 +5,10 @@ build:
   os: "ubuntu-lts-latest"
   tools:
     python: "3.13"
+  jobs:
+    install:
+      - pip install --upgrade pip
+      - pip install -e . --group docs
 
 sphinx:
   configuration: docs/conf.py
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "httpx>=0.23.1",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 docs = [
     "Sphinx==8.2.0",
     "furo==2025.7.19",


### PR DESCRIPTION
This is now supported by both Dependabot and Read the Docs.