### PR TITLE
vbml: assert that 'template' is non-None in branch

### DIFF
--- a/src/vesta/vbml.py
+++ b/src/vesta/vbml.py
@@ -136,7 +136,8 @@ class Component:
         d: Dict[str, Any] = {}
         if self.raw_characters is not None:
             d["rawCharacters"] = self.raw_characters
-        elif self.template is not None:
+        else:
+            assert self.template is not None
             d["template"] = self.template
         if self.style:
             d["style"] = self.style


### PR DESCRIPTION
The constructor guarantees at least one of template or raw_characters is set. Add an `assert` to prevent the "unreachable" case, which applies to both type checking and code coverage analysis.